### PR TITLE
Fixed wrong git clone command in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Tools and packages you need for development:
 You can then build and install the app by cloning this repository into the Nextcloud apps folder and running `make build`.
 ```bash
 cd /var/www/<NEXTCLOUD_INSTALL>/apps
-git clone https://github.com/R0Wi/nextcloud_workflow_ocr.git
+git clone https://github.com/R0Wi/nextcloud_workflow_ocr.git workflow_ocr
 cd workflow_ocr
 make build
 ```


### PR DESCRIPTION
Fixed the name of the local folder created by the Git clone command such that the following commands in the documentation succeed.